### PR TITLE
Sanitizing Configured API JSON

### DIFF
--- a/src/config_manager.ts
+++ b/src/config_manager.ts
@@ -61,7 +61,49 @@ export class ConfigManager {
         // only add apis that appear to be configured correctly,
         // cannot account for all user error here, other checks must be done elsewhere.
         for (let i = 0; i < rawApiArray.length; i++) {
-            safeApiArray.push(rawApiArray[i]);
+            // Boolean representing if an error has been found
+            let safe = true;
+            // A list of errors as strings
+            let errors = [];
+            let name = "UNNAMED API";
+            
+            if (!rawApiArray[i].name) {
+                errors.push("| Must define a name field |");
+                safe = false;
+            } else {
+                name = rawApiArray[i].name;
+            }
+
+            if (!rawApiArray[i].url) {
+                errors.push("| Must define a url field |");
+                safe = false;
+            }
+
+            if (!rawApiArray[i].method) {
+                errors.push("| Must define a method field, ex: POST, GET |");
+                safe = false;
+            }
+
+            if (!rawApiArray[i].type) {
+                errors.push("| Must define a type field |");
+                safe = false;
+            }
+
+            if (!rawApiArray[i].mapping) {
+                errors.push("| Must define a mapping field |");
+                safe = false;
+            }
+
+            if (safe) {
+                // Push the API, it is safe to use.
+                safeApiArray.push(rawApiArray[i]);
+            } else {
+                // Do not push the API, show the user the error(s).
+                vscode.window.showErrorMessage(
+                    "API CONFIG ERROR, " + name + ": " + errors.reduce((before,current,i) => 
+                        i == 0 ? current : before + " , " + current)
+                );
+            }
         }
 
         let strategies = new Array<APIStrategy>(0);
@@ -70,14 +112,14 @@ export class ConfigManager {
             switch (safeApiArray[i].method) {
                 case "POST":
 
-                    if (!safeApiArray[i].body) vscode.window.showWarningMessage("WARNING: Body undefined for: " + safeApiArray[i].name + ", and it is using " +
+                    if (!safeApiArray[i].body) vscode.window.showWarningMessage("CONFIG WARNING: Body undefined for: " + safeApiArray[i].name + ", and it is using " +
                         "a POST request, so it may be missing information.");
                     strategies.push(new PostStrategy(safeApiArray[i]));
 
                     break;
                 case "GET":
 
-                    if (safeApiArray[i].body) vscode.window.showWarningMessage("WARNING: Body defined for: " + safeApiArray[i].name + ", however it is using " +
+                    if (safeApiArray[i].body) vscode.window.showWarningMessage("CONFIG WARNING: Body defined for: " + safeApiArray[i].name + ", however it is using " +
                         "a GET request, so this information will not be used.");
                     strategies.push(new GetStrategy(safeApiArray[i]));
 
@@ -85,7 +127,7 @@ export class ConfigManager {
                 case "VirusTotal":
 
                     strategies.push(new VirusTotalStrategy(safeApiArray[i]));
-                    
+
                     break;
             }
         }

--- a/src/get_strategy.ts
+++ b/src/get_strategy.ts
@@ -2,6 +2,7 @@ import Axios from "axios";
 import { APIStrategy } from "./api_strategy";
 const FormData = require('form-data');
 var _ = require('lodash');
+import * as vscode from 'vscode';
 
 /**
  * The API Strategy for GET requests.
@@ -23,13 +24,6 @@ export class GetStrategy extends APIStrategy {
                 ...configHeaders
             },
         };
-
-        // Get the body from the configuration
-        let configBody = _.has(withToken,"body") ? withToken.body : undefined;
-
-        // Get requests do not use bodies, log warning if one exists.
-        if (configBody) console.log("WARNING: Body defined for: " + this.apiJSON.name + ", however it is using " +
-                                    "a GET request, so this information will not be used.");
 
         // Get data, replace string of interest with the token, add in the headers from the config
         let retval = await Axios.get(withToken.url, config);

--- a/src/post_strategy.ts
+++ b/src/post_strategy.ts
@@ -27,10 +27,6 @@ export class PostStrategy extends APIStrategy {
         // Get the body from the configuration
         let configBody = _.has(withToken, "body") ? withToken.body : undefined;
 
-        // Post requests usually use bodies, log warning if one does not exist.
-        if (!configBody) console.log("WARNING: Body undefined for: " + this.apiJSON.name + ", and it is using " +
-            "a POST request, so it may be missing information.");
-
         let retval = await axios.post(withToken.url + "?" + new URLSearchParams(withToken.query), configBody, config);
 
         // Cache the data for the token


### PR DESCRIPTION
Config manager will now only generate API/Strategy combos from vetted APIs that have required JSON values defined. While this does not check that an API will work, it does prevent the extension from breaking because an incomplete API does not have a required value.