### PR TITLE
Vt caching

### DIFF
--- a/src/api_strategy.ts
+++ b/src/api_strategy.ts
@@ -114,14 +114,14 @@ export abstract class APIStrategy {
         return "{" + this.apiID + "} " + lookupVal;
     }
 
-    private static apiCache: Cache<JSON>;
+    private static apiCache: Cache<any>;
     /**
      * Allows access to a universal cache
      * for all strategies to share. Strategies should
      * use getCacheKey when inserting and retrieving
      * values from the cache.
      */
-    protected static getSharedCache(): Cache<JSON> {
+    protected static getSharedCache(): Cache<any> {
         if (!this.apiCache) {
             this.apiCache = new MapCache();
             ConfigManager.getConfigManager().onDidUpdateConfiguration(() => this.apiCache.clearCache());

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,9 +11,17 @@ export interface Cache<T>{
 
     /**
      * Insert a value.
+     * @param cacheKey The unique caching key
      * @param value The value to be inserted
      */
     insertValue(cacheKey: any, value: T) : void;
+
+    /**
+     * Replace an existing value.
+     * @param cacheKey The unique caching key
+     * @param value The new value
+     */
+    replaceValue(cacheKey: any, value: T) : void;
 
     /**
      * Clear the cache.

--- a/src/map_cache.ts
+++ b/src/map_cache.ts
@@ -20,6 +20,10 @@ export class MapCache<T> implements Cache<T> {
         this.cacheMap.set(cacheKey, value);
     }
 
+    replaceValue(cacheKey: any, value: T): void {
+        this.cacheMap.set(cacheKey, value);
+    }
+
     clearCache(): void {
         this.cacheMap.clear();
         console.log("Cleared cache");

--- a/src/virus_total_strategy.ts
+++ b/src/virus_total_strategy.ts
@@ -2,6 +2,7 @@ import { APIStrategy } from "./api_strategy";
 import axios from 'axios';
 import { CommonDataModel } from "./api_calls";
 import { Console } from "console";
+import { resolve } from "promise";
 const FormData = require('form-data');
 
 /**
@@ -12,54 +13,114 @@ const FormData = require('form-data');
  */
 export default class VirusTotalStrategy extends APIStrategy {
     protected async getRawResponse(token: string): Promise<any> {
-        // Get values out of loaded config data
+        // Set up caching
+        let cache = APIStrategy.getSharedCache();
+        let cacheKey = this.getCacheKey(token);
+        let cacheResult = <any>cache.getCachedValue(cacheKey);
+
+        // If the cache is a completed VT response, return it
+        if (cacheResult && !(cacheResult.liveNotebookIDFlag) && cacheResult.attributes.status === "completed") {
+            return cacheResult;
+        }
+        // The cache is for an ID, resolve the ID w/ virus total analysis
+        else if (cacheResult && (cacheResult.liveNotebookIDFlag || cacheResult.attributes.status === "queued")) {
+            // Make a get request with the id, to see if we have valid data yet.
+            let getPromise = this.getVTIDResponse(cache.getCachedValue(cacheKey).id);
+
+            // Get the result
+            let VTResult = await getPromise.then((resp: any) => resp);
+
+            // Replace the old cached id, with the new analysis response
+            // we strip off the data tag on VT in our mapping, but
+            // we could just cache VTResult and it would work the same.
+            cache.replaceValue(cacheKey, VTResult.data);
+
+            return cache.getCachedValue(cacheKey);
+        } 
+        // We don't have a cached result or id, make initial call to virus total for an ID
+        else {
+            // Make the post request
+            let postPromise = this.postVTToken(token);
+
+            if (postPromise === undefined) {
+                console.error("Failed to get Virus Total URL result, token was: "+token);
+                return undefined;
+            } else {
+                // Get the unmodified Virus Total result
+                let VTResult = await postPromise.then((resp: any) => resp);
+                
+                // Modify the Virus Total result to include the idflag,
+                // This lets us know that this is not an analysis result,
+                // and just contains the id, instead of id + data.
+                VTResult.liveNotebookIDFlag = "exists";
+
+                // Insert the modified result into cache
+                cache.insertValue(cacheKey, VTResult);
+                return undefined;
+            }
+        }
+    }
+
+    /**
+     * POST the token (IP, URL, etc) to the virus total API
+     * and return the api response.
+     */
+    private async postVTToken(token: string): Promise<any | undefined> {
+        // Get the url to post to from the config
         let api_url = this.apiJSON.url;
 
+        // Create form data
         var formData = new FormData();
+        // Append the token as "url", which will be posted in the body
         formData.append("url", token);
+
+        // Create the headers, formdata.getheaders() provides
+        // information saying that the body is in formdata form.
         let virus_total_header = {
             headers: {
                 ...formData.getHeaders(),
                 ...this.apiJSON.headers
             },
         };
-        let post_resp = {
-            data: {
-                id: -1,
-            },
-        };
-        let resolve = async (resp: any) => {
-            post_resp.data = resp.data.data;
-            let url_id = post_resp.data.id;
-            if (url_id != undefined) {
-                let new_api_url = this.apiJSON.vturl2 + url_id;
-                let resolve = (resp: any) => {
-                    return resp.data.data;
-                };
-                return await axios
-                    .get(new_api_url, virus_total_header)
-                    .then(resolve);
-            } else {
-                return undefined;
+
+        let retval = await axios.post(api_url, formData, virus_total_header);
+
+        // All axios results have a data field
+        let result = retval.data;
+
+        // All VT responses have a data field, (this is retval.data.data now)
+        if (result.data) {
+            let resultData = result.data;
+            // Make sure that the id field exists
+            if (resultData.id) {
+                return resultData;
             }
         }
-        return axios
-            .post(api_url, formData, virus_total_header).then(resolve, (err: any) => {
-            console.error(err);
-            return err.message;
-            });
+
+        // If the request failed to return an id
+        return undefined;
     }
 
-    // protected normalize(mapping: object | string, response: any): CommonDataModel {
-    //     const date: Date = new Date(0);
-    //     date.setUTCSeconds(response.data.data.attributes.date)
-    //     const normalizedResponse: CommonDataModel = {
-    //         ...response.data.data.attributes,
-    //         api_name: "VirusTotal URL",
-    //         last_modification_date: date.toLocaleDateString(),
-    //         type: response.data.data.type,
-    //         links: response.data.data.links
-    //     };
-    //     return normalizedResponse
-    // }
+    /**
+     * Send a GET HTTP to Virus Total with the ID of
+     * the data we want to get back.
+     * Return the api response.
+     */
+    private async getVTIDResponse(id: string): Promise<any | undefined> {
+        // Add the id to the analysis VT url
+        let urlWithID = this.apiJSON.vturl2 + id;
+
+        // Create the GET headers (don't need form data headers for GET)
+        let virus_total_header = {
+            headers: {
+                ...this.apiJSON.headers
+            },
+        };
+
+        // Make the GET request
+        let retval = await axios.get(urlWithID, virus_total_header);
+
+        // Return the result without axios' data wrapper
+        return retval.data;
+    }
 }

--- a/src/virus_total_strategy.ts
+++ b/src/virus_total_strategy.ts
@@ -23,7 +23,7 @@ export default class VirusTotalStrategy extends APIStrategy {
             return cacheResult;
         }
         // The cache is for an ID, resolve the ID w/ virus total analysis
-        else if (cacheResult && (cacheResult.liveNotebookIDFlag || cacheResult.attributes.status === "queued")) {
+        else if (cacheResult && cacheResult.liveNotebookIDFlag) {
             // Make a get request with the id, to see if we have valid data yet.
             let getPromise = this.getVTIDResponse(cache.getCachedValue(cacheKey).id);
 
@@ -36,7 +36,6 @@ export default class VirusTotalStrategy extends APIStrategy {
                 // we could just cache VTResult and it would work the same.
                 cache.replaceValue(cacheKey, VTResult.data);
             }
-
             // This can return queued data, which will show up as zeroes,
             // which is better than showing no information.
             return VTResult.data;
@@ -45,7 +44,6 @@ export default class VirusTotalStrategy extends APIStrategy {
         else {
             // Make the post request
             let postPromise = this.postVTToken(token);
-
             if (postPromise === undefined) {
                 console.error("Failed to get Virus Total URL result, token was: "+token);
                 return undefined;


### PR DESCRIPTION
Implemented caching for the virus total API.

I explain further in my commit message:

- The virus total strategy now caches virus total responses in
the following way:
- First, if a cache entry does not exist, then
send the url to the virus total API and get back the response
that has your queue id. Cache that response with a special marker.
- Second, if a cache entry is marked as having a VT id, send that id out
  to the virus total analysis api and get back a response, if the
  response has attribute.status === "completed" cache it and return it,
  otherwise return it without caching, and eventually the response will
  come back with completed, and will be cached.
- Third, if a cache entry is not marked as having a VT id, then it is
  completed and can be returned immediately.