### PR TITLE
Removed Windows 2016 from CI CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,17 +65,6 @@ jobs:
           run: npm run compile
         - name: Run Test
           run: npm test
-  
-  Build-Pipeline-Windows-2016:
-    runs-on: windows-2016
-    steps:
-      - uses: actions/checkout@v2
-      - name: NPM Package Installation
-        run: npm install
-      - name: Build
-        run: npm run compile
-      - name: Run Test
-        run: npm test
 
   Build-Pipeline-MacOS-10:
       runs-on: macos-10.15


### PR DESCRIPTION
Windows 2016 is causing a lot of builds to fail. I guess the image of windows used by the VM is unstable