### PR TITLE
Reworked Config Dependencies (config_manager.ts, extension.ts)

### DIFF
--- a/src/api_calls.ts
+++ b/src/api_calls.ts
@@ -26,17 +26,37 @@ export type CommonDataModel = {
 }
 
 export class APICalls {
+    // The list of strategies to use
     private strategies: APIStrategy[];
 
     // Strategy for the sidebar
     private sideBarStrategy: APIStrategy | undefined;
 
-    constructor() {
-        this.strategies = ConfigManager.getConfigManager().getAPIStrategies();
-        ConfigManager.getConfigManager().onDidUpdateConfiguration(() => this.strategies = ConfigManager.getConfigManager().getAPIStrategies());
+    // The configuration manager to load api strategies from
+    private configManager : ConfigManager;
 
-        this.sideBarStrategy = ConfigManager.getConfigManager().getSidePanelStrategy();
-        ConfigManager.getConfigManager().onDidUpdateConfiguration(() => this.sideBarStrategy = ConfigManager.getConfigManager().getSidePanelStrategy());
+    constructor(configManager : ConfigManager) {
+        this.configManager = configManager;
+
+        if (!configManager)
+        {
+            throw new Error("APICalls was fed a null configuration manager!");
+        }
+
+        // Reset the API counter for api_strategy, TODO: create API factory class, and manage ids there instead of here
+        // Reset the API Counter on configuration update
+        this.configManager.onDidUpdateConfiguration(() => APIStrategy.resetAPICounter);
+
+        // Clear the API strategy cache, also too tightly coupled, TODO: find a fix
+        this.configManager.onDidUpdateConfiguration(() => APIStrategy.clearAPICache);
+
+        // Load the strategies, and set them so they are reloaded when the configuration changes
+        this.strategies = this.configManager.getAPIStrategies();
+        this.configManager.onDidUpdateConfiguration(() => this.strategies = this.configManager.getAPIStrategies());
+
+        // Load the sidebarstrategy, and set it so it reloades when the configuration changes
+        this.sideBarStrategy = this.configManager.getSidePanelStrategy();
+        this.configManager.onDidUpdateConfiguration(() => this.sideBarStrategy = this.configManager.getSidePanelStrategy());
     }
 
     /**

--- a/src/api_strategy.ts
+++ b/src/api_strategy.ts
@@ -1,7 +1,6 @@
 import { CommonDataModel } from "./api_calls"
 import { Cache } from "./cache";
 import { MapCache } from "./map_cache";
-import ConfigManager from "./config_manager";
 var _ = require('lodash');
 
 /**
@@ -31,18 +30,31 @@ export abstract class APIStrategy {
     constructor(apiJSON: any) {
         this.apiJSON = apiJSON;
 
-        // Reset the API Counter on configuration update
-        ConfigManager.getConfigManager().onDidUpdateConfiguration(() => APIStrategy.apiCounter = 0);
-
         // Increment api counter, set the apiID
-        this.apiID = APIStrategy.apiCounter++;
+        this.apiID = APIStrategy.getNextApiID();
+    }
 
+    /**
+     * @returns The next api ID, incremented by 1 each time
+     */
+    private static getNextApiID(): number {
+        APIStrategy.apiCounter++;
         // Overflow protection
         if (APIStrategy.apiCounter < 0) {
             APIStrategy.apiCounter = 0;
-            this.apiID = 0;
             throw new Error("Number of APIs exceeded maximum integer length!");
         }
+        return APIStrategy.apiCounter;
+    }
+
+    /**
+     * A function to be called by API_Calls,
+     * this couples the two classes tightly for now,
+     * a potential fix would be to pass in the API ID
+     * from outside the class. API Factory in config manager or API calls, etc
+     */
+    public static resetAPICounter(){
+        this.apiCounter = 0;
     }
 
     /**
@@ -127,8 +139,15 @@ export abstract class APIStrategy {
     protected static getSharedCache(): Cache<any> {
         if (!this.apiCache) {
             this.apiCache = new MapCache();
-            ConfigManager.getConfigManager().onDidUpdateConfiguration(() => this.apiCache.clearCache());
         }
         return this.apiCache;
+    }
+
+    /**
+     * Another tightly coupled method to
+     * be called from API_Calls
+     */
+    public static clearAPICache(){
+        this.apiCache.clearCache();
     }
 }

--- a/src/extended_results_provider.ts
+++ b/src/extended_results_provider.ts
@@ -3,17 +3,22 @@ import * as vscode from 'vscode';
 import { TokenMatcher } from "./token_matcher";
 
 export class ExtendedResultsProvider implements vscode.CodeActionProvider {
+	// The token matcher, matches tokens found in documents
+    private tokenMatcher : TokenMatcher;
+
+	constructor(tokenMatcher : TokenMatcher) {
+		this.tokenMatcher = tokenMatcher
+	}
 
 	public static readonly providedCodeActionKinds = [
 		vscode.CodeActionKind.QuickFix
 	];
 
 	provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, tok: vscode.CancellationToken): vscode.ProviderResult<(vscode.CodeAction | vscode.Command)[]> {
-		let tempMatcherObj = new TokenMatcher();
 		var matchRange: vscode.Range | undefined = document.getWordRangeAtPosition(range.start, /\S+/);
 		if (matchRange !== undefined) {
 			var token: string = document.getText(matchRange);
-			var type: string | undefined = tempMatcherObj.matchToken(token);
+			var type: string | undefined = this.tokenMatcher.matchToken(token);
 			if (type !== undefined) {
 				console.log("Inside provideCode Actions");
 				console.log(token);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,14 +5,23 @@ import APICalls from './api_calls';
 import { ExtendedResultsProvider } from './extended_results_provider'
 import { SidePanels } from "./side_panels";
 import DiagnositcsProvider from './diagnostics_provider';
+import ConfigManager from './config_manager';
 
 let diagnosticCollection: vscode.DiagnosticCollection;
+
+// The configuration name
+const configName : string = 'live-notebook';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	let globalMatcher: TokenMatcher = new TokenMatcher();
-	let apiCalls: APICalls = new APICalls();
+
+	// The config manager, manages loading APIs and Regular Expressions
+	let globalConfigManager: ConfigManager = new ConfigManager(vscode.workspace.getConfiguration(configName), configName); 
+	// The tokenmatcher, used to match otkens in documents
+	let globalMatcher: TokenMatcher = new TokenMatcher(globalConfigManager);
+	// APICalls, used to call APIs on tokens
+	let apiCalls: APICalls = new APICalls(globalConfigManager);
 
 	context.subscriptions.push(
 		vscode.languages.registerHoverProvider("plaintext", new NotebookHoverProvider(globalMatcher, apiCalls))
@@ -20,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Push the extended results provider
 	context.subscriptions.push(
-		vscode.languages.registerCodeActionsProvider('plaintext', new ExtendedResultsProvider())
+		vscode.languages.registerCodeActionsProvider('plaintext', new ExtendedResultsProvider(globalMatcher))
 	);
 
 

--- a/src/test/suite/diagnostics.test.ts
+++ b/src/test/suite/diagnostics.test.ts
@@ -4,6 +4,7 @@ import TokenMatcher from '../../token_matcher';
 import sinon from "ts-sinon";
 import * as tsSinon from "ts-sinon";
 import DiagnositcsProvider from '../../diagnostics_provider';
+import ConfigManager from '../../config_manager';
 
 suite('Diagnostics (Highlights) Test Suite',
     () => {
@@ -15,7 +16,15 @@ suite('Diagnostics (Highlights) Test Suite',
         onDidChangeTextDocument.returns(tsSinon.stubConstructor(vscode.Disposable));
         const onDidCloseTextDocument = sinon.stub(vscode.workspace, "onDidCloseTextDocument").returns(tsSinon.stubConstructor(vscode.Disposable));
         onDidCloseTextDocument.returns(tsSinon.stubConstructor(vscode.Disposable));
-        const mockMatcher = tsSinon.stubConstructor(TokenMatcher);
+
+        // Mock config manager to pass to  token matcher, necessary for test to run
+        let mockVSCodeConfig = tsSinon.stubInterface<vscode.WorkspaceConfiguration>();
+        mockVSCodeConfig.get.returns(
+            {"regexes" : []}
+        );
+	    const configManager : ConfigManager = new ConfigManager(mockVSCodeConfig, "fake name, not used in testing");
+
+        const mockMatcher = tsSinon.stubConstructor(TokenMatcher, configManager);
         mockMatcher.matchToken.withArgs("TEST TEXT").returns("TEST TYPE");
         const diagnosticsProvider = new DiagnositcsProvider(mockContext, mockMatcher);
 

--- a/src/test/suite/hover.test.ts
+++ b/src/test/suite/hover.test.ts
@@ -1,19 +1,25 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { Cache } from "../../cache";
-import { MapCache } from "../../map_cache";
 import TokenMatcher from '../../token_matcher';
 import APICalls, { CommonDataModel } from '../../api_calls';
 import NotebookHoverProvider from '../../hover_provider';
 import * as tsSinon from "ts-sinon";
-import { expectation } from 'sinon';
-import sinon from "ts-sinon";
+import ConfigManager from '../../config_manager';
 
 suite('Hover Test Suite',
     () => {
-        const mockMatcher = tsSinon.stubConstructor(TokenMatcher);
+        // Mock config manager to pass to apicalls and token matcher, necessary for test to run
+        let mockVSCodeConfig = tsSinon.stubInterface<vscode.WorkspaceConfiguration>();
+        mockVSCodeConfig.get.returns(
+            {"apis" : [],
+             "regexes" : []}
+        );
+	    const configManager : ConfigManager = new ConfigManager(mockVSCodeConfig, "fake name, not used in testing");
+
+        const mockMatcher = tsSinon.stubConstructor(TokenMatcher,configManager);
         mockMatcher.matchToken.withArgs("TEST TEXT").returns("TEST TYPE");
-        const mockAPICalls = tsSinon.stubConstructor(APICalls);
+
+        const mockAPICalls = tsSinon.stubConstructor(APICalls,configManager);
         mockAPICalls.getResponse.returns(Promise.allSettled(
             [Promise.resolve(<CommonDataModel>{
                 api_name: "TEST API"

--- a/src/test/suite/tokenMatchTest.test.ts
+++ b/src/test/suite/tokenMatchTest.test.ts
@@ -3,12 +3,35 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import ConfigManager from '../../config_manager';
+import * as tsSinon from "ts-sinon";
 import { TokenMatcher } from "../../token_matcher";
 
 suite('Token Matcher Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	let tokenMatcher = new TokenMatcher()
+	// Mock a vscode configuration
+	let mockVSCodeConfig = tsSinon.stubInterface<vscode.WorkspaceConfiguration>();
+	mockVSCodeConfig.get.returns(
+		[
+			{
+				"type": "URL",
+				"regex": "(?<=\\s|^)(https?://)?(www\\.)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?(?=\\s|$)"
+			},
+			{
+				"type": "IP",
+				"regex": "(?<=\\s|^)(\\d{1,3}\\.){3}\\d{1,3}(?=\\s|$)|(?<=\\s|^)(\\w{1,4}\\:){7}\\w{1,4}(?=\\s|$)|(?<=\\s|^)\\w{1,4}\\:(\\w{0,4}\\:){5}\\w{1,4}(?=\\s|$)"
+			},
+			{
+				"type": "EMAIL",
+				"regex": "(?<=\\s|^)[a-z0-9\\-\\.\\+]+@[a-z0-9\\-]+\\.[a-z0-9]+(?=\\s|$)"
+			}
+		]
+	);
+
+	const configManager : ConfigManager = new ConfigManager(mockVSCodeConfig, "fake name, not used in testing");
+
+	let tokenMatcher = new TokenMatcher(configManager);
 	
 	test("matchToken loadConfig",()=>{
 		// Test matchToken URL

--- a/src/token_matcher.ts
+++ b/src/token_matcher.ts
@@ -1,3 +1,4 @@
+import { Console } from 'console';
 import { type } from 'os';
 import * as vscode from 'vscode';
 import { ConfigManager } from './config_manager';
@@ -20,10 +21,13 @@ export type TypedRegex = {
 export class TokenMatcher {
     // The array of regex and type pairs.
     private regexes: Array<TypedRegex> = [];
+    // The configuration the tokenmatcher uses for its regular expressions
+    private configManager : ConfigManager;
 
     // The constructor initalizes the regexes array by loading data
     // from user settings.
-    constructor() {
+    constructor(configManager : ConfigManager) {
+        this.configManager = configManager;
         this.loadConfig();
     }
 
@@ -31,9 +35,14 @@ export class TokenMatcher {
      * Load regexes and their types from user settings
      */
     public loadConfig() {
+        if (this.configManager == null)
+        {
+            console.log("Null ConfigManager in tokenmatcher!");
+            return;
+        }
         // Load the regexes in the ConfigManager class
-        this.regexes = ConfigManager.getConfigManager().getTypedRegexes();
-        ConfigManager.getConfigManager().onDidUpdateConfiguration(() => this.regexes = ConfigManager.getConfigManager().getTypedRegexes());
+        this.regexes = this.configManager.getTypedRegexes();
+        this.configManager.onDidUpdateConfiguration(() => this.regexes = this.configManager.getTypedRegexes());
     }
 
     /**


### PR DESCRIPTION
- The config manager class constructor now takes a
  vscode.WorkspaceConfiguration parameter, and a configName parameter,
  allowing the configuration to be effectively mocked.

- API_Calls and TokenMatcher now take a configmanager parameter, to allow for
  dependency injection for test mocks.

- APIcalls now manages the
  ondidconfigurationupdates for APIStrategy through static method calls,
  this should be changed in the future, potentially with an
  APIStrategyFactory of some sort.

- extenions.ts now hosts the global version of ConfigManager, used by
  the global tokenmatcher and the global apiCalls, these should be the
  only instances of these classes outside of testing.

- Adjusted tests to add mocked configmanager injections, did not change
  what the tests were testing, should add tests related to configmanager
  in the future.