### PR TITLE
SearchParamsSupport (get_strategy.ts, post_strategy.ts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,29 @@
 					"default": [
 						{
 							"name": "WhoIsXmlAPI",
-							"url": "https://www.whoisxmlapi.com/whoisserver/WhoisService?apiKey=at_eK7TFzDjujemroNcccq6A4ScXF0HN&domainName={live-notebook.stringOfInterest}&outputFormat=JSON",
+							"url": "https://www.whoisxmlapi.com/whoisserver/WhoisService",
 							"method": "GET",
+							"query": [
+								{
+									"name" : "apiKey",
+									"value": "API_KEY_HERE"
+								},
+								{
+									"name" : "domainName",
+									"value": "{live-notebook.stringOfInterest}"
+								},
+								{
+									"name" : "outputFormat",
+									"value" : "JSON"
+								}
+								
+							],
 							"type": [
 								"URL",
 								"IP",
 								"EMAIL"
 							],
-							"isSidePanelAPI": true
+							"isSidePanelAPI": true 
 						},
 						{
 							"name": "Google Safe Browsing",
@@ -66,9 +81,12 @@
 							"type": [
 								"URL"
 							],
-							"query": {
-								"key": "{API_KEY_HERE}"
-							},
+							"query": [
+								{
+									"name" : "key",
+									"value" : "API_KEY_HERE"
+								}
+							],
 							"body": {
 								"threatInfo": {
 									"threatTypes": [
@@ -109,7 +127,7 @@
 								"IP"
 							],
 							"headers": {
-								"x-apikey": "{API_KEY_HERE}"
+								"x-apikey": "API_KEY_HERE"
 							},
 							"mapping": {
 								"last_modification_date": "data.attributes.last_modification_date",
@@ -141,7 +159,7 @@
 								"URL"
 							],
 							"headers": {
-								"x-apikey": "{API_KEY_HERE}"
+								"x-apikey": "API_KEY_HERE"
 							},
 							"mapping": {
 								"last_modification_date": "attributes.date",

--- a/src/get_strategy.ts
+++ b/src/get_strategy.ts
@@ -28,11 +28,11 @@ export class GetStrategy extends APIStrategy {
             },
         };
 
-        // Check if the api key is in search params
-        let keyInParams = _.has(withToken,"query");
+        // Check if the API uses URLSearch Parameters
+        let searchParamsExist = _.has(withToken,"query");
         let completedUrl = withToken.url;
 
-        if (keyInParams) {
+        if (searchParamsExist) {
             let mySearchParams = new URLSearchParams();
             let configParams = withToken.query;
 

--- a/src/get_strategy.ts
+++ b/src/get_strategy.ts
@@ -1,6 +1,7 @@
 import Axios from "axios";
 import { APIStrategy } from "./api_strategy";
 const FormData = require('form-data');
+import { URLSearchParams } from "url";
 var _ = require('lodash');
 import { Cache } from "./cache";
 
@@ -26,8 +27,13 @@ export class GetStrategy extends APIStrategy {
             },
         };
 
+        // Check if the api key is in search params
+        let keyInParams = _.has(withToken,"query");
+        let completedUrl = withToken.url;
+        if (keyInParams) completedUrl += "?" + new URLSearchParams(withToken.query);
+
         // Get data, replace string of interest with the token, add in the headers from the config
-        let retval = await Axios.get(withToken.url, config);
+        let retval = await Axios.get(completedUrl, config);
 
         // Cache the data for the token
         if (cache) cache.insertValue(this.getCacheKey(token), retval.data);

--- a/src/get_strategy.ts
+++ b/src/get_strategy.ts
@@ -4,6 +4,7 @@ const FormData = require('form-data');
 import { URLSearchParams } from "url";
 var _ = require('lodash');
 import { Cache } from "./cache";
+import { Console } from "console";
 
 /**
  * The API Strategy for GET requests.
@@ -30,7 +31,16 @@ export class GetStrategy extends APIStrategy {
         // Check if the api key is in search params
         let keyInParams = _.has(withToken,"query");
         let completedUrl = withToken.url;
-        if (keyInParams) completedUrl += "?" + new URLSearchParams(withToken.query);
+
+        if (keyInParams) {
+            let mySearchParams = new URLSearchParams();
+            let configParams = withToken.query;
+
+            for (let i = 0; i < configParams.length; i++){
+                mySearchParams.append(configParams[i].name,configParams[i].value);
+            }
+            completedUrl += "?" + mySearchParams;
+        }
 
         // Get data, replace string of interest with the token, add in the headers from the config
         let retval = await Axios.get(completedUrl, config);

--- a/src/post_strategy.ts
+++ b/src/post_strategy.ts
@@ -32,7 +32,16 @@ export class PostStrategy extends APIStrategy {
         // Check if the api key is in search params
         let keyInParams = _.has(withToken,"query");
         let completedUrl = withToken.url;
-        if (keyInParams) completedUrl += "?" + new URLSearchParams(withToken.query);
+
+        if (keyInParams) {
+            let mySearchParams = new URLSearchParams();
+            let configParams = withToken.query;
+
+            for (let i = 0; i < configParams.length; i++){
+                mySearchParams.append(configParams[i].name,configParams[i].value);
+            }
+            completedUrl += "?" + mySearchParams;
+        }
 
         let retval = await axios.post(completedUrl, configBody, config);
 

--- a/src/post_strategy.ts
+++ b/src/post_strategy.ts
@@ -29,11 +29,11 @@ export class PostStrategy extends APIStrategy {
         // Get the body from the configuration
         let configBody = _.has(withToken, "body") ? withToken.body : undefined;
 
-        // Check if the api key is in search params
-        let keyInParams = _.has(withToken,"query");
+        // Check if the API uses URLSearch Parameters
+        let searchParamsExist = _.has(withToken,"query");
         let completedUrl = withToken.url;
 
-        if (keyInParams) {
+        if (searchParamsExist) {
             let mySearchParams = new URLSearchParams();
             let configParams = withToken.query;
 

--- a/src/post_strategy.ts
+++ b/src/post_strategy.ts
@@ -29,7 +29,12 @@ export class PostStrategy extends APIStrategy {
         // Get the body from the configuration
         let configBody = _.has(withToken, "body") ? withToken.body : undefined;
 
-        let retval = await axios.post(withToken.url + "?" + new URLSearchParams(withToken.query), configBody, config);
+        // Check if the api key is in search params
+        let keyInParams = _.has(withToken,"query");
+        let completedUrl = withToken.url;
+        if (keyInParams) completedUrl += "?" + new URLSearchParams(withToken.query);
+
+        let retval = await axios.post(completedUrl, configBody, config);
 
         // Cache the data for the token
         if (cache) cache.insertValue(this.getCacheKey(token), retval.data);


### PR DESCRIPTION
- GET strategy now supports putting the API key in URLSearchParams.
- POST strategy now supports not having API key in URLSearchParams.